### PR TITLE
Set media_dirs path for local file extension.

### DIFF
--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -296,3 +296,12 @@ scan_timeout = 1000
 scan_flush_threshold = 1000
 excluded_file_extensions = .html, .jpeg, .jpg, .log, .nfo, .png, .txt, .mkv, .avi, .divx, .qt, .wmv, .htm, .zip, .rar, .gz, .pdf, .exe, .ini, .mid, .db, .m3u, .sfv, .midi
 
+[file]
+enabled = true
+media_dirs =
+    /music|Music
+    ~/|Home
+show_dotfiles = false
+follow_symlinks = false
+metadata_timeout = 1000
+


### PR DESCRIPTION
Mopidy sets the default media directory to:

```
media_dirs =
    $XDG_MUSIC_DIR|Music
    ~/|Home
```

...but as the `$XDG_MUSIC_DIR` environment variable is not set on the Pi Musicbox by default, and `~/Home` does not contain any music files by default, it is not possible to browse local media using the Mopidy 'files' extension.

I'm not sure whether there is a general drive to adopt all of the `XDG` environment parameters on Pi Musibox, but we probably need to either:

(a) set all of the XDG relevant environment variables, in which case the Mopidy defaults will work, or 
(b) override the default extension configuration and insert the relevant static paths for Pi Musicbox

This PR contains the fixes for (b).
