### PR TITLE
Added support for wifi configuration base on regulatory region.

### DIFF
--- a/create_musicbox0.7.sh
+++ b/create_musicbox0.7.sh
@@ -49,6 +49,9 @@ apt-get remove --yes --purge linux-wlan-ng
 # Ensure we reinstall the upstream config.
 apt-get install --yes -o Dpkg::Options::="--force-confmiss" --reinstall avahi-daemon
 
+# Get the packages required for setting wifi region
+apt-get install --yes wireless-regdb crda
+
 # Upgrade!
 apt-get dist-upgrade --yes -o Dpkg::Options::="--force-confnew"
 

--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -18,6 +18,10 @@
 wifi_network = 
 wifi_password = 
 
+# Set the wifi region for correct regulatory configuration.
+# Use the ISO / IEC 3166 alpha2 country code, e.g. wifi_country = GB
+wifi_country = 
+
 # Set the name of the MusicBox. 
 # In this way you can identify and access different devices on the same network e.g. across different rooms.
 # A MusicBox device named kitchen would be accessible from a web browser at http://kitchen.local/, from an MPD 

--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -91,6 +91,14 @@ chmod u+s /sbin/shutdown
 if [ "$INI__network__wifi_network" != "" ]
 then
     #put wifi settings for wpa roaming
+	#
+	# If wifi_country is set then include a country=XX line
+    if [ "$INI__network__wifi_country" != "" ]
+    then
+        WIFICOUNTRY="country=$INI__network__wifi_country"
+    else
+        WIFICOUNTRY=""
+    fi
     if [ "$INI__network__wifi_password" != "" ]
     then
         password_length=${#INI__network__wifi_password}
@@ -103,6 +111,7 @@ then
         cat >/etc/wpa.conf <<EOF
             ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
             update_config=1
+            $WIFICOUNTRY
             network={
                 ssid="$INI__network__wifi_network"
                 psk=$PSK
@@ -114,6 +123,7 @@ EOF
         cat >/etc/wpa.conf <<EOF
             ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
             update_config=1
+            $WIFICOUNTRY
             network={
                 ssid="$INI__network__wifi_network"
                 key_mgmt=NONE


### PR DESCRIPTION
This allows wifi channels to be available base on regulatory region.

Added installing `wireless-regdb` and `crda` packages needed to support this.

Created a `wifi_country` setting and the add support for this to `startup.sh` to add a `country=XX` line to the generated wpa.conf file.
